### PR TITLE
Fix AMD overlay font on iOS Safari

### DIFF
--- a/css/barron-roth.webflow.css
+++ b/css/barron-roth.webflow.css
@@ -390,8 +390,8 @@ h1 {
 }
 
 .image-overlay-text._5 {
-  font-family: Awesome Serif Italic, Times New Roman, sans-serif;
-  font-style: normal;
+  font-family: "Awesome Serif Italic Extra Tall", Times New Roman, sans-serif;
+  font-style: italic;
   font-weight: 700;
   position: static;
 }
@@ -484,10 +484,10 @@ h1 {
 .image-overlay-text-sm {
   color: var(--overlay-text-color);
   margin-top: -14px;
-  font-family: Awesome Serif Italic Tall, Times New Roman, sans-serif;
+  font-family: "Awesome Serif Italic Tall", Times New Roman, sans-serif;
   font-size: 23px;
-  font-style: normal;
-  font-weight: 700;
+  font-style: italic;
+  font-weight: 400;
 }
 
 .image-overlay-text-sm._2 {


### PR DESCRIPTION
## Summary
- update overlay font definitions to reference existing *Awesome Serif* families
- correct font style/weight to match loaded fonts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684646fca160832288cfd1aced51b30b