### PR TITLE
Fix card layout overflow on wide screens

### DIFF
--- a/css/barron-roth.webflow.css
+++ b/css/barron-roth.webflow.css
@@ -553,6 +553,11 @@ h1 {
   
   .image-wrapper {
     padding: 50px 60px 50px 60px;
+    overflow: hidden;
+  }
+
+  .content-wrapper {
+    padding-right: 80px;
   }
 
   .card-heading {


### PR DESCRIPTION
## Summary
- ensure card overflow doesn't show extra background
- give text column more padding on large screens

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6847b24dbc5c8322b2937849754a01c9