### PR TITLE
Update Google and Shopify blurbs

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
               <div class="text-23-red">2025–Present</div>
               <div class="text-23-purple">Product</div>
             </div>
-            <div class="text-block">At Google, I'm working on agents that help harness agents for organizations at scale.</div>
+            <div class="text-block">At Google, I work on what it takes to make AI agents useful at organizational scale.</div>
             <a href="https://deepmind.google/models/" target="_blank" class="button w-button">Learn More</a>
           </div>
         </div>
@@ -87,7 +87,7 @@
               <div class="text-23-red">2022–2025</div>
               <div class="text-23-purple">Product</div>
             </div>
-            <div class="text-block">I’ve spent the last couple of years building retail software at Shopify, as a Product Manager on Shopify POS. I’ve gotten the opportunity to ship numerous innovations combining physical and digital commerce, like the ability to Ship from Store.</div>
+            <div class="text-block">At Shopify, I worked on 0-to-1 experiments in agentic commerce and built products for Shopify POS that connected online and in-store retail.</div>
             <a href="https://www.modernretail.co/technology/shopify-is-rolling-out-a-store-fulfillment-option-for-its-brick-and-mortar-merchants/" target="_blank" class="button w-button">Learn More</a>
           </div>
           <div id="w-node-_222b58c1-15c3-efd3-2b5c-ae12473d0ee3-10555a30" class="image-wrapper">


### PR DESCRIPTION
## Summary
- replace the circular Google agents copy with a broader organizational-scale line
- reposition the Shopify blurb around agentic commerce and Shopify POS

## Verification
- `git diff --check`
- parsed `index.html` with Python HTMLParser
- verified both cards in the local browser preview at desktop width